### PR TITLE
Source/Minor: Improve error checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ cmake_minimum_required(VERSION 3.10)
 project(polley)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -fstandalone-debug")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -fstandalone-debug -fsanitize=address")
+
 add_executable(${PROJECT_NAME} main.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC -lcurl -lpthread -lz -lcrypto)
+
+include(cmake/CPM.cmake)
+
+CPMAddPackage(NAME curl VERSION 8.3.0 GITHUB_REPOSITORY curl/curl GIT_TAG curl-8_3_0)
+CPMAddPackage(NAME Zlib VERSION 1.3 GITHUB_REPOSITORY madler/zlib GIT_TAG v1.3)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC libcurl -lpthread zlib crypto)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.38.5)
+set(CPM_HASH_SUM "192aa0ccdc57dfe75bd9e4b176bf7fb5692fd2b3e3f7b09c74856fc39572b31c")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})


### PR DESCRIPTION
To notify the parent thread when the fetching thread dies we add a new variable task_fail. The parent
thread extends its waiting thread with this variable. It checks to see if it is not null. If it is, then the fetching thread has failed unexpectedly. We
should exit also.

We add the check for to compute SHA of all data
used by the make_tree process and we validate
against the one send at the close to the end of
transmission by the server.

We use CURLOPT_*TIMEOUT variables to set the maximum time for waiting thread to stay alive when the
server's response speed drops below 30bytes for up to 1 minute.

We improve dependency management by the use of CMake Package Manager(CPM). With this, we are assured to give a better developer experience.